### PR TITLE
Extend Component to Accept `legendType` and `legendSize` as Props

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "@inubekit/foundations": "^5.10.0",
-    "@inubekit/stack": "^3.5.0"
+    "@inubekit/stack": "^3.5.0",
+    "@inubekit/text": "^2.13.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/Fieldset/index.tsx
+++ b/src/Fieldset/index.tsx
@@ -1,22 +1,39 @@
-import { StyledFieldset, StyledLegend } from "./styles";
+import { StyledFieldset } from "./styles";
 import { IFieldsetSpacing } from "./props";
 import { Stack } from "@inubekit/stack";
+import { IText, Text } from "@inubekit/text";
 
 interface IFieldset {
   legend: string;
   children: React.ReactNode;
   spacing?: IFieldsetSpacing;
+  type: IText["type"];
+  size: IText["size"];
+  width?: string;
+  height?: string;
 }
 
 function Fieldset(props: IFieldset) {
-  const { legend, children, spacing = "compact" } = props;
+  const {
+    legend,
+    children,
+    spacing = "compact",
+    type = "title",
+    size = "medium",
+    width = "auto",
+    height = "auto",
+  } = props;
 
   return (
     <StyledFieldset $spacing={spacing}>
-      <StyledLegend>{legend}</StyledLegend>
+      <legend>
+        <Text appearance="gray" type={type} size={size} margin="0 0 0 6px">
+          {legend}
+        </Text>
+      </legend>
       <Stack
-        height="100%"
-        width="100%"
+        height={height}
+        width={width}
         padding={spacing === "wide" ? "24px 20px" : "16px 12px"}
       >
         {children}

--- a/src/Fieldset/props.ts
+++ b/src/Fieldset/props.ts
@@ -1,5 +1,7 @@
 const spacings = ["compact", "wide"] as const;
 type IFieldsetSpacing = (typeof spacings)[number];
+const types = ["body", "display", "headline", "label", "title"] as const;
+const sizes = ["large", "medium", "small"] as const;
 
 const parameters = {
   docs: {
@@ -11,20 +13,34 @@ const parameters = {
 };
 
 const props = {
-  legend: {
-    description:
-      "A string that represents the title or heading for the fieldset component.",
-  },
-
   children: {
     description:
       "A prop that expects React nodes as its value, used to render the content inside the fieldset.",
   },
-
+  height: {
+    description: "Sets the height of the Stack component within the fieldset.",
+  },
+  legend: {
+    description:
+      "A string that represents the title or heading for the fieldset component.",
+  },
+  size: {
+    control: "select",
+    options: sizes,
+    description: "Specifies the text size for the legend.",
+  },
   spacing: {
     control: "select",
     options: spacings,
-    description: "Controls the spacing of the legend",
+    description: "Controls the spacing of the legend.",
+  },
+  type: {
+    control: "select",
+    options: types,
+    description: "Specifies the text type for the legend.",
+  },
+  width: {
+    description: "Sets the width of the Stack component within the fieldset.",
   },
 };
 

--- a/src/Fieldset/styles.js
+++ b/src/Fieldset/styles.js
@@ -9,22 +9,11 @@ const StyledFieldset = styled.fieldset`
   border-style: solid;
   border-color: ${({ theme }) =>
     theme?.fieldset?.border?.color || inube.fieldset.border.color};
-  padding: 0;
+  padding-left: 24px;
   > *:not(:first-child) {
     margin-top: -8px;
     min-height: 150px;
   }
 `;
 
-const StyledLegend = styled.legend`
-  font-family: Roboto, sans-serif;
-  line-height: 20px;
-  font-size: 14px;
-  letter-spacing: 0.1px;
-  font-weight: 500;
-  color: ${({ theme }) =>
-    theme?.fieldset?.legend?.color || inube.fieldset.legend.color};
-  margin-left: 24px;
-`;
-
-export { StyledFieldset, StyledLegend };
+export { StyledFieldset };


### PR DESCRIPTION
This pull request extends the component to include two new props: `legendType` and `legendSize`. These props allow developers to customize the text type and size for the legend element within a fieldset, offering greater flexibility in how legends are displayed.