### PR TITLE
Move fieldset tokens from foundations to component

### DIFF
--- a/src/Fieldset/Tokens/tokens.ts
+++ b/src/Fieldset/Tokens/tokens.ts
@@ -1,0 +1,12 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  legend: {
+    color: inube.palette.neutral.N200,
+  },
+  border: {
+    color: inube.palette.neutral.N40,
+  },
+};
+
+export { tokens };

--- a/src/Fieldset/stories/styles.js
+++ b/src/Fieldset/stories/styles.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const StyledChildren = styled.div`
   width: 100%;
@@ -9,9 +8,9 @@ const StyledChildren = styled.div`
   border-width: 0px;
   border-style: solid;
   border-color: ${({ theme }) =>
-    theme?.fieldset?.border?.color || inube.fieldset.border.color};
+    theme?.fieldset?.border?.color || tokens.border.color};
   background-color: ${({ theme }) =>
-    theme?.fieldset?.legend?.color || inube.fieldset.legend.color};
+    theme?.fieldset?.legend?.color || tokens.legend.color};
   background-color: gray;
 `;
 

--- a/src/Fieldset/styles.js
+++ b/src/Fieldset/styles.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledFieldset = styled.fieldset`
   display: flex;
@@ -8,7 +7,7 @@ const StyledFieldset = styled.fieldset`
   border-width: 1px;
   border-style: solid;
   border-color: ${({ theme }) =>
-    theme?.fieldset?.border?.color || inube.fieldset.border.color};
+    theme?.fieldset?.border?.color || tokens.border.color};
   padding: ${({ $isMobile }) =>
     $isMobile ? "8px 12px 16px" : "12px 20px 24px"};
   height: ${({ $height }) => $height};


### PR DESCRIPTION
This PR relocates the fieldset tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring that components are referencing the correct token paths. This refactor improves the overall organization, maintainability, and clarity of the codebase.